### PR TITLE
Refactored the python code example

### DIFF
--- a/read_english_dictionary.py
+++ b/read_english_dictionary.py
@@ -1,16 +1,11 @@
-import json
-import os, sys
-
 def load_words():
-    try:
-        filename = os.path.dirname(sys.argv[0])+"\\"+"words_dictionary.json"
-        with open(filename,"r") as english_dictionary:
-            valid_words = json.load(english_dictionary)
-            return valid_words
-    except Exception as e:
-        return str(e)
+    with open('words_alpha.txt') as word_file:
+        valid_words = set(word_file.read().split())
+
+    return valid_words
+
 
 if __name__ == '__main__':
     english_words = load_words()
     # demo print
-    print(english_words["fate"])
+    print('fate' in english_words)


### PR DESCRIPTION
Problems as listed in the commit message

- `sys` imported and unused.
- `os` only used to create cwd which is implied with `open`
- `try`/`except` block that doesn't handle anything
- `json` loaded to create a more expensive defaultdict
- dict created just for membership testing instead of set
- membership test performed by fetching key value instead of using in

When I first cloned the repo I used the example and I went "Great, this works".  Then I looked at it and was really confused with how it was working.

The `open` command by default tries to open the file in the `.` directory (current working).  So creating an absolute path was unneeded.

The `json.load()` reads a `.json` file and returns a `dict`.  It was the equivalent of iterating over the plain text file and creating a `dict` entry with `valid_words[word] = 1`.

The `try`/`except` block does catch some errors but it just returns it as a string.  So when you attempt to lookup the work "fate" it would have thrown `TypeError: string indices must be integers` which would have made troubleshooting much more difficult.  If the exception isn't going to be handled, it's best to just let it raise itself and the actual problem will occur immediately, like a `FileNotFound` exception which is much easier to diagnose.

Lastly, when membership testing in Python it's almost always best to use the `in` keyword.  Just trying to reference the key directly results in exceptions that need to be handled and makes the code less readable.  For example if instead of "fate" you looked up "fatex" it would throw a `KeyError` exception.  So you can either change the `dict` lookup to `english_words.get('fatex', 0)` or even better you can use the `in` keyword on dicts `'fatex' in english_words`.  Though at that point why have a dict if the values never matter, which is why it was changed to return a `set()`.