### PR TITLE
Add archived dataset ref link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ english-words
 A text file containing over 466k English words.
 
 While searching for a list of english words (for an auto-complete tutorial)
-I found: http://stackoverflow.com/questions/2213607/how-to-get-english-language-word-database which refers to ~~http://www.infochimps.com/datasets/word-list-350000-simple-english-words-excel-readable~~ (link no longer available).
+I found: http://stackoverflow.com/questions/2213607/how-to-get-english-language-word-database which refers to [http://www.infochimps.com/datasets/word-list-350000-simple-english-words-excel-readable](https://web.archive.org/web/20131118073324/http://www.infochimps.com/datasets/word-list-350000-simple-english-words-excel-readable) (archived).
 
 No idea why infochimps put the word list inside an excel (.xls) file.
 


### PR DESCRIPTION
- Replace plain obsolete dataset link to infochimps with archived link to make it easier to refer to.
- The webpage could display normally as it used to be. Unfortunately, the xls file download link is broken ultimately, but it may not be a big problem as the words have already been saved to the repo.