### PR TITLE
Fix find positional argument issue

### DIFF
--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -32,4 +32,4 @@ cp words.txt words_alpha.txt
 grep -v '[[:alpha:]]*' words_alpha.txt
 python3 scripts/create_json.py words_alpha.txt > words_dictionary.json
 rm *.zip
-find . -type f -name "words*" -maxdepth 1 -execdir zip '{}.zip' '{}' \;
+find . -maxdepth 1 -type f -name "words*" -execdir zip '{}.zip' '{}' \;


### PR DESCRIPTION
Previously, running on GNU Find 4.8.0 yielded this warning:

>find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.